### PR TITLE
refactor : article, summary Indexing + 캐싱

### DIFF
--- a/src/main/java/com/team5/on_stage/OnStageApplication.java
+++ b/src/main/java/com/team5/on_stage/OnStageApplication.java
@@ -2,10 +2,12 @@ package com.team5.on_stage;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableCaching
 public class OnStageApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/team5/on_stage/article/entity/Article.java
+++ b/src/main/java/com/team5/on_stage/article/entity/Article.java
@@ -14,7 +14,12 @@ import org.hibernate.annotations.Where;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "article")
+@Table(
+        name = "article",
+        indexes = {
+                @Index(name = "idx_status", columnList = "status")
+        }
+)
 @Where(clause = "is_deleted = false")
 public class Article {
     @Id

--- a/src/main/java/com/team5/on_stage/article/repository/ArticleQueryDslRepository.java
+++ b/src/main/java/com/team5/on_stage/article/repository/ArticleQueryDslRepository.java
@@ -1,5 +1,10 @@
 package com.team5.on_stage.article.repository;
 
+import com.team5.on_stage.article.entity.Article;
+
+import java.util.List;
+
 public interface ArticleQueryDslRepository {
     void softDeleteByUsername(String username);
+    List<Article> findByStatus(String status);
 }

--- a/src/main/java/com/team5/on_stage/article/repository/ArticleQueryDslRepositoryImpl.java
+++ b/src/main/java/com/team5/on_stage/article/repository/ArticleQueryDslRepositoryImpl.java
@@ -1,10 +1,14 @@
 package com.team5.on_stage.article.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team5.on_stage.article.entity.Article;
+import com.team5.on_stage.article.entity.ArticleStatus;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 import static com.team5.on_stage.article.entity.QArticle.article;
 
@@ -27,5 +31,14 @@ public class ArticleQueryDslRepositoryImpl implements ArticleQueryDslRepository 
             em.flush();
             em.clear();
 
+    }
+
+    @Override
+    public List<Article> findByStatus(String status) {
+        return queryFactory
+                .select(article)
+                .from(article)
+                .where(article.status.eq(ArticleStatus.valueOf(status)))
+                .fetch();
     }
 }

--- a/src/main/java/com/team5/on_stage/global/config/RedisConfig.java
+++ b/src/main/java/com/team5/on_stage/global/config/RedisConfig.java
@@ -3,13 +3,17 @@ package com.team5.on_stage.global.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @RequiredArgsConstructor
@@ -55,5 +59,17 @@ public class RedisConfig {
                 .setConnectionFactory(redisConnectionFactory());
 
         return redisTemplate;
+    }
+
+    // Todo - 직렬화
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(cacheConfig)
+                .build();
     }
 }

--- a/src/main/java/com/team5/on_stage/global/config/redis/RedisService.java
+++ b/src/main/java/com/team5/on_stage/global/config/redis/RedisService.java
@@ -1,8 +1,13 @@
 package com.team5.on_stage.global.config.redis;
 
 
+import com.team5.on_stage.user.entity.User;
+import com.team5.on_stage.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
@@ -15,7 +20,7 @@ import java.time.Duration;
 public class RedisService {
 
     private final RedisTemplate<String, String> redisTemplate;
-
+    private final UserRepository userRepository;
 
     /* Refresh Token */
 
@@ -119,6 +124,21 @@ public class RedisService {
 
         redisTemplate.delete(key);
     }
+
+    @Cacheable(value = "userNicknameCache", key = "#username")
+    public String getUserNickname(String username) {
+        User user = userRepository.findByUsername(username);
+        return user.getNickname();
+    }
+
+    @CachePut(value = "userNicknameCache", key = "#username")
+    public String updateUserNicknameCache(String username, String newNickname) {
+        return newNickname;
+    }
+
+
+
+
 
 
 }

--- a/src/main/java/com/team5/on_stage/summary/entity/Summary.java
+++ b/src/main/java/com/team5/on_stage/summary/entity/Summary.java
@@ -18,9 +18,14 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name="summary")
-//@Where(clause = "is_deleted = false")
 @EntityListeners(AuditingEntityListener.class)
+//@Where(clause = "is_deleted = false")
+@Table(
+        name = "summary",
+        indexes = {
+                @Index(name = "idx_created_at", columnList = "created_at DESC")
+        }
+)
 public class Summary {
 
     @Id

--- a/src/main/java/com/team5/on_stage/summary/service/SummaryService.java
+++ b/src/main/java/com/team5/on_stage/summary/service/SummaryService.java
@@ -3,6 +3,7 @@ package com.team5.on_stage.summary.service;
 import com.team5.on_stage.article.entity.Article;
 import com.team5.on_stage.article.repository.ArticleRepository;
 import com.team5.on_stage.article.service.ArticleService;
+import com.team5.on_stage.global.config.redis.RedisService;
 import com.team5.on_stage.summary.dto.SummaryRequestDTO;
 import com.team5.on_stage.summary.dto.SummaryResponseDTO;
 
@@ -34,6 +35,7 @@ public class SummaryService {
     private final SummaryMapper summaryMapper;
     private final ChatGPTService chatGPTService;
     private final UserRepository userRepository;
+    private final RedisService redisService;
 
     // username별로 닉네임 정보 캐싱
     private final Map<String, String> userNicknameCache = new ConcurrentHashMap<>();
@@ -106,8 +108,10 @@ public class SummaryService {
     // 해당 userId의 뉴스 요약 가져오기 (페이지네이션 적용)
     public Page<SummaryResponseDTO> getRecentSummary(SummaryRequestDTO request) {
         String username = request.getUsername();
-        User user = userRepository.findByUsername(username);
-        String currentNickname = user.getNickname();
+        //User user = userRepository.findByUsername(username);
+        //String currentNickname = user.getNickname();
+
+        String currentNickname = redisService.getUserNickname(username);
 
         // prevNickname 가져오기
         String prevNickname = userNicknameCache.get(username);

--- a/src/main/java/com/team5/on_stage/user/service/UserService.java
+++ b/src/main/java/com/team5/on_stage/user/service/UserService.java
@@ -57,6 +57,8 @@ public class UserService {
         checkNicknameDuplicated(nickname);
         user.setNickname(nickname);
         userRepository.save(user);
+
+        redisService.updateUserNicknameCache(username, nickname);
     }
 
     public void updateUserDescription(String username,


### PR DESCRIPTION
close #5 

- article의 검수상태에 인덱싱과, summary의 최신순 정렬을 위한 created_at 기준 인덱싱을 적용했습니다.
- 각 유저의 닉네임을 캐싱하고, 닉네임 업데이트 시 새로운 닉네임을 캐싱하는 로직을 추가했습니다.